### PR TITLE
plugin: don't try to copy file onto itself

### DIFF
--- a/hatch_build_scripts/plugin.py
+++ b/hatch_build_scripts/plugin.py
@@ -55,7 +55,7 @@ class BuildScriptsHook(BuildHookInterface):
                 src_file = work_dir / work_file
                 out_file = out_dir / work_file
                 log.debug(f"Copying {src_file} to {out_file}")
-                if src_file not in created:
+                if src_file not in created and src_file != out_file:
                     out_file.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copyfile(src_file, out_file)
                     created.add(out_file)


### PR DESCRIPTION
If the command generates the artifact in the right place, there's no need to copy it to out directory

Closes #8

## Issues

#8

## Summary

If the command generates the artifact in the right place, there's no need to copy it to out directory